### PR TITLE
Avoid walking preprocessed map on GetAll

### DIFF
--- a/discovery/discoveryclient/client.go
+++ b/discovery/discoveryclient/client.go
@@ -412,19 +412,7 @@ func (c *DefaultClient) GetAllHandlersForAppID(appID string) (announcements []*d
 	if err != nil {
 		return nil, err
 	}
-	seen := make(map[*discovery.Announcement]struct{})
-	for announced, handlers := range all.announcementsByAppID {
-		if appID == announced {
-			for _, handler := range handlers {
-				if _, seen := seen[handler]; seen {
-					continue
-				}
-				announcements = append(announcements, handler)
-				seen[handler] = struct{}{}
-			}
-		}
-	}
-	return
+	return all.announcementsByAppID[appID], nil
 }
 
 // GetAllRoutersForGatewayID returns all routers that can handle the given GatewayID
@@ -433,19 +421,7 @@ func (c *DefaultClient) GetAllRoutersForGatewayID(gatewayID string) (announcemen
 	if err != nil {
 		return nil, err
 	}
-	seen := make(map[*discovery.Announcement]struct{})
-	for announced, routers := range all.announcementsByGatewayID {
-		if gatewayID == announced {
-			for _, router := range routers {
-				if _, seen := seen[router]; seen {
-					continue
-				}
-				announcements = append(announcements, router)
-				seen[router] = struct{}{}
-			}
-		}
-	}
-	return
+	return all.announcementsByGatewayID[gatewayID], nil
 }
 
 // Close purges the cache and closes the connection with the Discovery server


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This quickfix ensures that we don't walk all of the announcements while looking for a specific `appID`/`gatewayID`.

#### Changes
<!-- What are the changes made in this pull request? -->

- Directly access map instead of using loop

#### Testing

<!-- How did you verify that this change works? -->

Unit tests.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I lost the `pprof` dump but this is on the `broker` hot-path on both uplink and activation. 

Are the `seen` sets still needed ?

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
